### PR TITLE
feat: Enable caching for eslint

### DIFF
--- a/configs/husky.js
+++ b/configs/husky.js
@@ -3,6 +3,6 @@
 module.exports = {
   hooks: {
     'pre-commit':
-      'lint-staged && eslint --no-eslintrc --config node_modules/@smartcar/zamboni/configs/eslintrc-for-all-files.js --no-inline-config .',
+      'lint-staged && eslint --cache --no-eslintrc --config node_modules/@smartcar/zamboni/configs/eslintrc-for-all-files.js --no-inline-config .',
   },
 };

--- a/configs/lintstaged.js
+++ b/configs/lintstaged.js
@@ -9,5 +9,5 @@ module.exports = {
   'package.json': 'sort-package-json',
 
   // eslint
-  '*.{js,jsx}': 'eslint --fix',
+  '*.{js,jsx}': 'eslint --cache --fix',
 };


### PR DESCRIPTION
This improves the performance of eslint when it is run during pre-commit hooks. On my machine this reduced the time to make a commit on API from 17 seconds to 4 seconds.

Note: The first run will still be slow since the cache needs to be built first, but future runs after that will benefit from the cache.